### PR TITLE
feat: add ability to assign arbitrary permissions to different resource types

### DIFF
--- a/examples/all_roles_account/README.md
+++ b/examples/all_roles_account/README.md
@@ -1,0 +1,26 @@
+# Single Service Account
+
+This example illustrates how to use the `service-accounts` module to generate a single service account.
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| email | The service account email. |
+| iam\_email | The service account IAM-format email. |
+
+[^]: (autogen_docs_end)
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/all_roles_account/main.tf
+++ b/examples/all_roles_account/main.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 2.7.0"
+}
+
+
+resource "google_storage_bucket" "test_bucket" {
+  project = "${var.project_id}"
+  name    = "${var.bucket_name}"
+}
+
+module "all_roles" {
+  source                = "../.."
+  project_id            = "${var.project_id}"
+  org_id                = "${var.org_id}"
+  prefix                = "${var.prefix}"
+  names                 = ["all-roles-account"]
+  project_roles         = ["${var.project_id}=>roles/viewer"]
+  org_roles             = ["${var.org_id}=>roles/compute.admin"]
+  bucket_roles          = ["${var.bucket_name}=>roles/storage.objectViewer"]
+  billing_account_roles = ["${var.billing_account_id}=>roles/billing.admin"]
+}

--- a/examples/all_roles_account/outputs.tf
+++ b/examples/all_roles_account/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "email" {
+  description = "The service account email."
+  value       = "${module.all_roles.email}"
+}
+
+output "iam_email" {
+  description = "The service account IAM-format email."
+  value       = "${module.all_roles.iam_email}"
+}

--- a/examples/all_roles_account/variables.tf
+++ b/examples/all_roles_account/variables.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = "string"
+}
+
+variable "prefix" {
+  description = "Prefix applied to service account names."
+  default     = ""
+}
+
+variable "org_id" {
+  description = "Organization to grant the service accounts access to"
+}
+
+variable "billing_account_id" {
+  description = "Billing account to grant access to"
+}
+
+variable "bucket_name" {
+  description = "Name of bucket to use for testing"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,17 +29,32 @@ variable "names" {
 }
 
 variable "project_roles" {
-  description = "Common roles to apply to all service accounts, project=>role as elements."
+  description = "Common roles to bind to all service accounts for the specified project, project_id=>role as elements."
+  default     = []
+}
+
+variable "org_roles" {
+  description = "Common organization roles to bind to all service accounts."
+  default     = []
+}
+
+variable "bucket_roles" {
+  description = "Common roles to bind to all service accounts for the specified GCS bucket, bucket_id=>role as elements."
+  default     = []
+}
+
+variable "billing_account_roles" {
+  description = "Common roles to bind to all service accounts for the specified billing accounts, billing_account_id=>role as elements."
   default     = []
 }
 
 variable "grant_billing_role" {
-  description = "Grant billing user role."
+  description = "Grant the billing user role"
   default     = false
 }
 
 variable "billing_account_id" {
-  description = "If assigning billing role, specificy a billing account (default is to assign at the organizational level)."
+  description = "If assigning billing role, specify a billing account (default is to assign at the organizational level)."
   default     = ""
 }
 


### PR DESCRIPTION
Adds the ability to bind an arbitrary number of permissions to the organization, a GCS bucket, or a billing account without breaking the existing API. 