### PR TITLE
Refactor outputs for 0.12, switch from maps to lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to
 
 ## [Unreleased]
 
-- **Backwards-incompatible change:** outputs for multiple resource now return lists instead of maps, so that the same order of the input variable is kept.
-- Added new outputs to expose the base resources.
-- Refactored the `iam_emails` output to use the new `for` expression, fixing   issues with `formatlist` and `zipmap` in Terraform 0.12.
+- Added new `service_account` and `service_accounts` outputs for single and multi user use that expose the base resources, now possible with Terraform 0.12.
+- Added new `emails_list` and `iam_emails_list` outputs that return lists, and are guaranteed to keep the same ordering for resources as the map type outputs.
+- Refactored the formatted list generation for the `iam_emails` and new `iam_emails_list` outputs to use the new `for` expression, fixing   issues with `formatlist` and `zipmap` in Terraform 0.12.
 - Refactored and simplified the `keys` template and output using the new splat syntax.
 
 ## [1.0.0] - 2019-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **Backwards-incompatible change:** outputs for multiple resource now return lists instead of maps, so that the same order of the input variable is kept.
+- Added new outputs to expose the base resources.
+- Refactored the `iam_emails` output to use the new `for` expression, fixing   issues with `formatlist` and `zipmap` in Terraform 0.12.
+- Refactored and simplified the `keys` template and output using the new splat syntax.
+
 ## [1.0.0] - 2019-07-26
 
 ### CHANGED

--- a/README.md
+++ b/README.md
@@ -37,33 +37,35 @@ module "service_accounts" {
 Functional examples are included in the
 [examples](./examples/) directory.
 
-[^]: (autogen_docs_start)
-
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | billing\_account\_id | If assigning billing role, specificy a billing account (default is to assign at the organizational level). | string | `""` | no |
-| generate\_keys | Generate keys for service accounts. | string | `"false"` | no |
-| grant\_billing\_role | Grant billing user role. | string | `"false"` | no |
-| grant\_xpn\_roles | Grant roles for shared VPC management. | string | `"true"` | no |
-| names | Names of the service accounts to create. | list | `<list>` | no |
+| generate\_keys | Generate keys for service accounts. | bool | `"false"` | no |
+| grant\_billing\_role | Grant billing user role. | bool | `"false"` | no |
+| grant\_xpn\_roles | Grant roles for shared VPC management. | bool | `"true"` | no |
+| names | Names of the service accounts to create. | list(string) | `<list>` | no |
 | org\_id | Id of the organization for org-level roles. | string | `""` | no |
 | prefix | Prefix applied to service account names. | string | `""` | no |
 | project\_id | Project id where service account will be created. | string | n/a | yes |
-| project\_roles | Common roles to apply to all service accounts, project=>role as elements. | list | `<list>` | no |
+| project\_roles | Common roles to apply to all service accounts, project=>role as elements. | list(string) | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| email | Service account email (single-use case). |
-| emails | Map of service account emails. |
-| iam\_email | IAM-format service account email (single-use case). |
+| email | Service account email (for single use). |
+| emails | Service account emails. |
+| iam\_email | IAM-format service account email (for single use). |
 | iam\_emails | IAM-format service account emails. |
+| key | Service account key (for single use). |
 | keys | Map of service account keys. |
+| service\_account | Service account resource (for single use). |
+| service\_accounts | Service account resources. |
 
-[^]: (autogen_docs_end)
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Functional examples are included in the
 [examples](./examples/) directory.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/examples/multiple_service_accounts/README.md
+++ b/examples/multiple_service_accounts/README.md
@@ -2,8 +2,7 @@
 
 This example illustrates how to use the `service-accounts` module to generate multiple service accounts.
 
-[^]: (autogen_docs_start)
-
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -18,7 +17,7 @@ This example illustrates how to use the `service-accounts` module to generate mu
 | iam\_emails | The service account IAM-format emails. |
 | keys | The service account keys. |
 
-[^]: (autogen_docs_end)
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 To provision this example, run the following from within this directory:
 - `terraform init` to get the plugins

--- a/examples/multiple_service_accounts/outputs.tf
+++ b/examples/multiple_service_accounts/outputs.tf
@@ -16,12 +16,12 @@
 
 output "emails" {
   description = "The service account emails."
-  value       = module.service_accounts.emails
+  value       = module.service_accounts.emails_list
 }
 
 output "iam_emails" {
   description = "The service account IAM-format emails."
-  value       = module.service_accounts.iam_emails
+  value       = module.service_accounts.iam_emails_list
 }
 
 output "keys" {

--- a/examples/multiple_service_accounts/outputs.tf
+++ b/examples/multiple_service_accounts/outputs.tf
@@ -16,12 +16,17 @@
 
 output "emails" {
   description = "The service account emails."
+  value       = module.service_accounts.emails
+}
+
+output "emails_list" {
+  description = "The service account emails as a list."
   value       = module.service_accounts.emails_list
 }
 
 output "iam_emails" {
-  description = "The service account IAM-format emails."
-  value       = module.service_accounts.iam_emails_list
+  description = "The service account IAM-format emails as a map."
+  value       = module.service_accounts.iam_emails
 }
 
 output "keys" {

--- a/examples/multiple_service_accounts/outputs.tf
+++ b/examples/multiple_service_accounts/outputs.tf
@@ -16,12 +16,12 @@
 
 output "emails" {
   description = "The service account emails."
-  value       = values(module.service_accounts.emails)
+  value       = module.service_accounts.emails
 }
 
 output "iam_emails" {
   description = "The service account IAM-format emails."
-  value       = values(module.service_accounts.iam_emails)
+  value       = module.service_accounts.iam_emails
 }
 
 output "keys" {

--- a/examples/single_service_account/README.md
+++ b/examples/single_service_account/README.md
@@ -2,12 +2,12 @@
 
 This example illustrates how to use the `service-accounts` module to generate a single service account.
 
-[^]: (autogen_docs_start)
-
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| prefix | Prefix applied to service account names. | string | `""` | no |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
 
 ## Outputs
@@ -17,7 +17,7 @@ This example illustrates how to use the `service-accounts` module to generate a 
 | email | The service account email. |
 | iam\_email | The service account IAM-format email. |
 
-[^]: (autogen_docs_end)
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 To provision this example, run the following from within this directory:
 - `terraform init` to get the plugins

--- a/examples/single_service_account/outputs.tf
+++ b/examples/single_service_account/outputs.tf
@@ -16,7 +16,7 @@
 
 output "email" {
   description = "The service account email."
-  value       = module.service_accounts.email
+  value       = module.service_accounts.service_account.email
 }
 
 output "iam_email" {

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
   org_billing     = var.grant_billing_role && var.billing_account_id == "" && var.org_id != ""
   prefix          = var.prefix != "" ? "${var.prefix}-" : ""
   xpn             = var.grant_xpn_roles && var.org_id != ""
+  iam_emails      = [for s in google_service_account.service_accounts : "serviceAccount:${s.email}"]
 }
 
 # create service accounts

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "service_account" {
   value       = google_service_account.service_accounts[0]
 }
 
+output "email" {
+  description = "Service account email (for single use)."
+  value       = google_service_account.service_accounts[0].email
+}
+
 output "iam_email" {
   description = "IAM-format service account email (for single use)."
   value       = "serviceAccount:${google_service_account.service_accounts[0].email}"
@@ -32,6 +37,11 @@ output "key" {
 output "service_accounts" {
   description = "Service account resources."
   value       = google_service_account.service_accounts
+}
+
+output "emails" {
+  description = "Service account emails."
+  value       = google_service_account.service_accounts[*].email
 }
 
 output "iam_emails" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,18 +25,15 @@ output "iam_email" {
 }
 
 output "emails" {
-  description = "Map of service account emails."
-  value       = zipmap(var.names, google_service_account.service_accounts.*.email)
+  description = "List of service account emails."
+  value       = google_service_account.service_accounts.*.email
 }
 
 output "iam_emails" {
-  description = "IAM-format service account emails."
-  value = zipmap(
-    var.names,
-    formatlist(
-      "serviceAccount:%s",
-      google_service_account.service_accounts.*.email,
-    ),
+  description = "List of IAM-format service account emails."
+  value = formatlist(
+    "serviceAccount:%s",
+    google_service_account.service_accounts.*.email,
   )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,10 +41,20 @@ output "service_accounts" {
 
 output "emails" {
   description = "Service account emails."
-  value       = google_service_account.service_accounts[*].email
+  value       = zipmap(var.names, google_service_account.service_accounts[*].email)
 }
 
 output "iam_emails" {
+  description = "IAM-format service account emails."
+  value       = zipmap(var.names, local.iam_emails)
+}
+
+output "emails_list" {
+  description = "Service account emails."
+  value       = google_service_account.service_accounts[*].email
+}
+
+output "iam_emails_list" {
   description = "IAM-format service account emails."
   value       = [for s in google_service_account.service_accounts : "serviceAccount:${s.email}"]
 }
@@ -63,4 +73,3 @@ output "keys" {
   sensitive   = true
   value       = zipmap(var.names, data.template_file.keys[*].rendered)
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
-output "email" {
-  description = "Service account email (single-use case)."
-  value       = google_service_account.service_accounts[0].email
+output "service_account" {
+  description = "Service account resource (for single use)."
+  value       = google_service_account.service_accounts[0]
 }
 
 output "iam_email" {
-  description = "IAM-format service account email (single-use case)."
+  description = "IAM-format service account email (for single use)."
   value       = "serviceAccount:${google_service_account.service_accounts[0].email}"
 }
 
-output "emails" {
-  description = "List of service account emails."
-  value       = google_service_account.service_accounts.*.email
+output "key" {
+  description = "Service account key (for single use)."
+  value       = data.template_file.keys[0].rendered
+}
+
+output "service_accounts" {
+  description = "Service account resources."
+  value       = google_service_account.service_accounts
 }
 
 output "iam_emails" {
-  description = "List of IAM-format service account emails."
-  value = formatlist(
-    "serviceAccount:%s",
-    google_service_account.service_accounts.*.email,
-  )
+  description = "IAM-format service account emails."
+  value       = [for s in google_service_account.service_accounts : "serviceAccount:${s.email}"]
 }
 
 data "template_file" "keys" {
@@ -42,21 +44,13 @@ data "template_file" "keys" {
   template = "$${key}"
 
   vars = {
-    key = var.generate_keys ? base64decode(
-      element(
-        concat(google_service_account_key.keys.*.private_key, [""]),
-        count.index,
-      ),
-    ) : ""
+    key = var.generate_keys ? base64decode(google_service_account_key.keys[count.index].private_key) : ""
   }
 }
 
 output "keys" {
   description = "Map of service account keys."
   sensitive   = true
-  value = zipmap(
-    formatlist("%s-key.json", var.names),
-    data.template_file.keys.*.rendered,
-  )
+  value       = zipmap(var.names, data.template_file.keys[*].rendered)
 }
 

--- a/test/fixtures/multiple_service_accounts/outputs.tf
+++ b/test/fixtures/multiple_service_accounts/outputs.tf
@@ -19,6 +19,16 @@ output "emails" {
   value       = module.example.emails
 }
 
+output "iam_emails" {
+  description = "The service account IAM-format emails."
+  value       = module.example.iam_emails
+}
+
+output "keys" {
+  description = "The service account keys."
+  value       = module.example.keys
+}
+
 output "project_id" {
   description = "Project id variable."
   value       = var.project_id

--- a/test/fixtures/multiple_service_accounts/outputs.tf
+++ b/test/fixtures/multiple_service_accounts/outputs.tf
@@ -19,8 +19,13 @@ output "emails" {
   value       = module.example.emails
 }
 
+output "emails_list" {
+  description = "The service account emails as a list."
+  value       = module.example.emails_list
+}
+
 output "iam_emails" {
-  description = "The service account IAM-format emails."
+  description = "The service account IAM-format emails as a map."
   value       = module.example.iam_emails
 }
 

--- a/test/integration/multiple_service_accounts/controls/gcp.rb
+++ b/test/integration/multiple_service_accounts/controls/gcp.rb
@@ -15,15 +15,18 @@
 control "gcp" do
   title "GCP Resources"
 
-  attribute('emails').each do |email|
-    describe google_service_accounts(project: "#{attribute('project_id')}") do
-      its('service_account_emails'){ should include email }
-    end
+  attribute('iam_emails').each_value do |email|
     describe google_project_iam_binding(project: "#{attribute("project_id")}",  role: 'roles/viewer') do
-      its('members') {should include "serviceAccount:#{email}" }
+      its('members') {should include email }
     end
     describe google_project_iam_binding(project: "#{attribute("project_id")}",  role: 'roles/storage.objectViewer') do
-      its('members') {should include "serviceAccount:#{email}" }
+      its('members') {should include email }
+    end
+  end
+
+  attribute('emails_list').each do |email|
+    describe google_service_accounts(project: "#{attribute('project_id')}") do
+      its('service_account_emails'){ should include email }
     end
   end
 

--- a/test/integration/multiple_service_accounts/inspec.yml
+++ b/test/integration/multiple_service_accounts/inspec.yml
@@ -10,3 +10,6 @@ attributes:
   - name: emails
     required: true
     type: array
+  - name: iam_emails
+    required: true
+    type: array

--- a/test/integration/multiple_service_accounts/inspec.yml
+++ b/test/integration/multiple_service_accounts/inspec.yml
@@ -9,7 +9,10 @@ attributes:
     type: string
   - name: emails
     required: true
+    type: hash
+  - name: emails_list
+    required: true
     type: array
   - name: iam_emails
     required: true
-    type: array
+    type: hash


### PR DESCRIPTION
This is one of the PRs we need for Fabric, that switch outputs in modules supporting multiple resources from maps to list. The rationale is to keep the same order passed in input variables (eg `names` here) for outputs, which lists do but maps don't as they reorder keys lexically. Having a different order in output vars tripped up ourselves and a few customers in the past.

This also:

- adds outputs for the base `google_service_account` resources, since it's now possible with Terraform 0.12;
- fixes an issue with `formatlist` in 0.12 where the resulting list always has a nominal length of 1 and cannot e combined with other list of the same (effective) length, switching to using the new `for` construct is cleaner and works better.

It's a backwards-incompatible change, so it needs a major version bump. Tests and example have been updated accordingly.