### PR TITLE
Add support for custom display_name and description #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Added
 
+- Support for `display_name` and `description` [#18]
 - Use `for_each` instead of `count` [#15]
 
 ## [2.0.2] - 2019-10-09

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | billing\_account\_id | If assigning billing role, specificy a billing account (default is to assign at the organizational level). | string | `""` | no |
+| description | Descriptions of the created service accounts (defaults to no description) | string | `""` | no |
+| display\_name | Display names of the created service accounts (defaults to 'Terraform-managed service account') | string | `"Terraform-managed service account"` | no |
 | generate\_keys | Generate keys for service accounts. | bool | `"false"` | no |
 | grant\_billing\_role | Grant billing user role. | bool | `"false"` | no |
 | grant\_xpn\_roles | Grant roles for shared VPC management. | bool | `"true"` | no |

--- a/examples/multiple_service_accounts/main.tf
+++ b/examples/multiple_service_accounts/main.tf
@@ -24,6 +24,8 @@ module "service_accounts" {
   prefix        = ""
   names         = ["test-first", "test-second"]
   generate_keys = true
+  display_name  = "Test Service Accounts"
+  description   = "Test Service Accounts description"
 
   project_roles = [
     "${var.project_id}=>roles/viewer",

--- a/examples/multiple_service_accounts/main.tf
+++ b/examples/multiple_service_accounts/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 3.17.0"
 }
 
 module "service_accounts" {

--- a/examples/single_service_account/main.tf
+++ b/examples/single_service_account/main.tf
@@ -24,5 +24,7 @@ module "service_accounts" {
   prefix        = var.prefix
   names         = ["single-account"]
   project_roles = ["${var.project_id}=>roles/viewer"]
+  display_name  = "Single Account"
+  description   = "Single Account Description"
 }
 

--- a/examples/single_service_account/main.tf
+++ b/examples/single_service_account/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 3.17.0"
 }
 
 module "service_accounts" {

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,8 @@ locals {
 resource "google_service_account" "service_accounts" {
   for_each     = local.names
   account_id   = "${local.prefix}${lower(each.value)}"
-  display_name = "Terraform-managed service account"
+  display_name = var.display_name
+  description  = var.description
   project      = var.project_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,14 @@ variable "generate_keys" {
   default     = false
 }
 
+variable "display_name" {
+  type        = string
+  description = "Display names of the created service accounts (defaults to 'Terraform-managed service account')"
+  default     = "Terraform-managed service account"
+}
+
+variable "description" {
+  type        = string
+  description = "Descriptions of the created service accounts (defaults to no description)"
+  default     = ""
+}


### PR DESCRIPTION
This PR resolves #18 

Multiple options to resolve this issue.

Simplest solution (and the chosen one): One `display_name` and `description` for all created service accounts. This one is imho the simplest and should fit most use cases.

Other solutions:

- Having `display_names` and `descriptions` as map where the key is the name of the service   account and the value is the display_name / description of the corresponding service account. Did not choose this solution since it adds much more complexity and is also more error prone (the service account name must match the display name key in the map). Also we would have 2 maps here (one for `display_names` and one for `descriptions`).
Example would look like this:
```
module "service_accounts" {
  source        = "../.."
  project_id    = var.project_id
  prefix        = var.prefix
  names         = ["single-account"]
  project_roles = ["${var.project_id}=>roles/viewer"]
  display_names = {
    single-account = "Single Account"
  }
  descriptions  = {
    single-account = "Single Account Description"
  }
}
```
- Having `display_names` and `descriptions` as array list. Same as the map solution. Also error prone since the indices have to match.
Example would look like this:
```
module "service_accounts" {
  source        = "../.."
  project_id    = var.project_id
  prefix        = var.prefix
  names         = ["single-account"]
  project_roles = ["${var.project_id}=>roles/viewer"]
  display_names = ["Single Account"]
  descriptions  = ["Single Account Description"]
}
```
- Having one map `metadata` where the key is the service account name and the value is again a map with the keys `display_name` and `description`. This one also adds more complexity since the structure is more complex even within the map and also error prone as the others since the service account name again has to match the key in the map.
Example would look like this:
```
module "service_accounts" {
  source        = "../.."
  project_id    = var.project_id
  prefix        = var.prefix
  names         = ["single-account"]
  project_roles = ["${var.project_id}=>roles/viewer"]
  metadata = {
    single-account = {
      display_name = "Single Account"
      description = "Single Account Description"
    }
  }
}
```

Of course would love to hear other opinions and happy to implement whatever seems like the best option. In my opinion this solution adds this functionality without adding much complexity. 