### PR TITLE
Enable decsription overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | billing\_account\_id | If assigning billing role, specificy a billing account (default is to assign at the organizational level). | `string` | `""` | no |
-| description | Descriptions of the created service accounts (defaults to no description) | `string` | `""` | no |
+| description | Default description of the created service accounts (defaults to no description) | `string` | `""` | no |
+| descriptions | List of descriptions for the created service accounts (elements default to the value of `description`) | `list(string)` | `[]` | no |
 | display\_name | Display names of the created service accounts (defaults to 'Terraform-managed service account') | `string` | `"Terraform-managed service account"` | no |
 | generate\_keys | Generate keys for service accounts. | `bool` | `false` | no |
 | grant\_billing\_role | Grant billing user role. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "google_service_account" "service_accounts" {
   for_each     = local.names
   account_id   = "${local.prefix}${lower(each.value)}"
   display_name = var.display_name
-  description  = index(local.names, each.value) > length(var.descriptions) - 1 ? var.description : element(var.descriptions, index(local.names, each.value))
+  description  = index(var.names, each.value) >= length(var.descriptions) ? var.description : element(var.descriptions, index(var.names, each.value))
   project      = var.project_id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "google_service_account" "service_accounts" {
   for_each     = local.names
   account_id   = "${local.prefix}${lower(each.value)}"
   display_name = var.display_name
-  description  = var.description
+  description  = index(local.names, each.value) > length(var.descriptions) - 1 ? var.description : element(var.descriptions, index(local.names, each.value))
   project      = var.project_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "display_name" {
 
 variable "description" {
   type        = string
-  description = "Descriptions of the created service accounts (defaults to no description)"
+  description = "Default description of the created service accounts (defaults to no description)"
   default     = ""
+}
+
+variable "descriptions" {
+  type        = list(string)
+  description = "List of descriptions for the created service accounts (elements default to the value of `description`)"
+  default     = []
 }


### PR DESCRIPTION
Resolves terraform-google-modules/terraform-google-service-accounts#39

Descriptions list overrides default description value. Should be a safe solution for arbitrary lengths of name and description lists.