### PR TITLE
fix: declare "key" output as sensitive value

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,7 @@ output "iam_email" {
 
 output "key" {
   description = "Service account key (for single use)."
+  sensitive   = true
   value       = var.generate_keys ? base64decode(google_service_account_key.keys[var.names[0]].private_key) : ""
 }
 


### PR DESCRIPTION
Currently creating a single serviceaccount with `generate_keys=true` failed with the following error:

```
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 32:
│   32: output "key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
ERRO[0011] 1 error occurred:
        * exit status 1
```
Fix #45 