### PR TITLE
Fix tfstate update during destroy operation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
   org_billing           = var.grant_billing_role && var.billing_account_id == "" && var.org_id != ""
   prefix                = var.prefix != "" ? "${var.prefix}-" : ""
   xpn                   = var.grant_xpn_roles && var.org_id != ""
-  service_accounts_list = [for name in var.names : google_service_account.service_accounts[name]]
+  service_accounts_list = [for account in google_service_account.service_accounts : account]
   emails_list           = [for account in local.service_accounts_list : account.email]
   iam_emails_list       = [for email in local.emails_list : "serviceAccount:${email}"]
   names                 = toset(var.names)

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,17 +16,17 @@
 
 output "service_account" {
   description = "Service account resource (for single use)."
-  value       = local.service_accounts_list[0]
+  value       = try(local.service_accounts_list[0], null)
 }
 
 output "email" {
   description = "Service account email (for single use)."
-  value       = local.emails_list[0]
+  value       = try(local.emails_list[0], null)
 }
 
 output "iam_email" {
   description = "IAM-format service account email (for single use)."
-  value       = local.iam_emails_list[0]
+  value       = try(local.iam_emails_list[0], null)
 }
 
 output "key" {
@@ -47,12 +47,12 @@ output "service_accounts_map" {
 
 output "emails" {
   description = "Service account emails by name."
-  value       = zipmap(var.names, local.emails_list)
+  value       = zipmap(local.service_accounts_list[*].name, local.emails_list)
 }
 
 output "iam_emails" {
   description = "IAM-format service account emails by name."
-  value       = zipmap(var.names, local.iam_emails_list)
+  value       = zipmap(local.service_accounts_list[*].name, local.iam_emails_list)
 }
 
 output "emails_list" {


### PR DESCRIPTION
_tl;dr_
This module currently fails to update outputs after destroy operation, this PR is intended to fix that condition.

_long version_
`var.names` which is provided by user during instantiation is not a best reference for actual state of the infrastructure. For that reason I'd like to propose to change to use `google_service_account.service_accounts` instead. This guarantees that whenever `service_accounts_list` is lazy loaded the values are accurate. Scenario which I experienced is as follows:
- I plan a destroy
- I apply previously generated plan
- apply fails with following error:
```
Error: Invalid index

  on main.tf line 22, in locals:
  22:   service_accounts_list = [for name in var.names : google_service_account.service_accounts[name]]
    |----------------
    | google_service_account.service_accounts is object with no attributes

The given key does not identify an element in this collection value.
```
The service account is properly removed and tfstate is updated, but outputs are not updated properly and terraform exits with error code.
This is because those values are lazy loaded and if we try to evaluate them after the resource is actually deleted we can't find matching entries when performing this lookup: `google_service_account.service_accounts[name]`. Enumerating the `google_service_account.service_accounts` into list solves the issue, because in case when service account is already deleted we get an empty list. Change also introduces minor changes too outputs to properly account for destroy operation.
