### PR TITLE
docs: more precise project_roles documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Functional examples are included in the
 | org\_id | Id of the organization for org-level roles. | `string` | `""` | no |
 | prefix | Prefix applied to service account names. | `string` | `""` | no |
 | project\_id | Project id where service account will be created. | `string` | n/a | yes |
-| project\_roles | Common roles to apply to all service accounts, project=>role as elements. | `list(string)` | `[]` | no |
+| project\_roles | Common roles to apply to all service accounts listed under names, project=>role as elements. | `list(string)` | `[]` | no |
 
 ## Outputs
 


### PR DESCRIPTION
We got confused by the wording, roles dont apply to all service accounts inside the project just for the ones defined under the names attribute.