### PR TITLE
fix: fixes Readme.md example due to many breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Basic usage of this module is as follows:
 ```hcl
 module "service_accounts" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 3.0"
+  version       = "~> 4.2.0"
   project_id    = "<PROJECT ID>"
   prefix        = "test-sa"
   names         = ["first", "second"]


### PR DESCRIPTION
Updating the Readme example due to many breaking changes

```sh
Error: Incompatible provider version

Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
package available for your current platform, darwin_arm64.

Provider releases are separate from Terraform CLI releases, so not all
providers are available for all platforms. Other versions of this provider
may have different platforms supported.
```

>I agree with @stuart-c - For those landing on this article in 2022/2023, please, make sure you stop using the Template Provider as it has been deprecated 71. Instead, use templatefile 134.

[FORUM](https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099)