### PR TITLE
fix: update minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Basic usage of this module is as follows:
 ```hcl
 module "service_accounts" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 3.0"
+  version       = "~> 4.0"
   project_id    = "<PROJECT ID>"
   prefix        = "test-sa"
   names         = ["first", "second"]


### PR DESCRIPTION
I noticed that if I used the example in the README, version ~3.0, Terraform fails to plan, due to the old obsolete version of provider `hashicorp/template`.

Had to use version ~4.0 for Terraform to plan successfully.

I also notice this README is ~2 years old; I recommend re-running `terraform-docs markdown table . --output-file README.md --output-mode inject` on it, to update any potentially out of date documentation.