### PR TITLE
feat: Add iam_email and env_vars output to simple-sa submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+	  -e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/examples/simple_sa/README.md
+++ b/examples/simple_sa/README.md
@@ -14,6 +14,8 @@ This example shows how to use the `simple-sa` submodule.
 | Name | Description |
 |------|-------------|
 | email | Service account email |
+| env\_vars | Exported environment variables |
+| iam\_email | IAM format service account email |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple_sa/outputs.tf
+++ b/examples/simple_sa/outputs.tf
@@ -18,3 +18,13 @@ output "email" {
   description = "Service account email"
   value       = module.sa.email
 }
+
+output "iam_email" {
+  description = "IAM format service account email"
+  value       = module.sa.iam_email
+}
+
+output "env_vars" {
+  description = "Exported environment variables"
+  value       = module.sa.env_vars
+}

--- a/modules/simple-sa/README.md
+++ b/modules/simple-sa/README.md
@@ -36,6 +36,8 @@ module "sa" {
 | Name | Description |
 |------|-------------|
 | email | Service account email |
+| env\_vars | Exported environment variables |
+| iam\_email | IAM format service account email |
 | id | Service account id and email |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -65,6 +65,10 @@ spec:
     outputs:
       - name: email
         description: Service account email
+      - name: env_vars
+        description: Exported environment variables
+      - name: iam_email
+        description: IAM format service account email
       - name: id
         description: Service account id and email
   requirements:

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -34,5 +34,6 @@ output "id" {
 
 output "env_vars" {
   description = "Exported environment variables"
-  value = { "SERVICE_ACCOUNT": google_service_account.sa.email}
+  value = { "SERVICE_ACCOUNT_EMAIL" : google_service_account.sa.email,
+  "SERVICE_ACCOUNT_IAM_EMAIL" : "serviceAccount:${google_service_account.sa.email}" }
 }

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -19,6 +19,11 @@ output "email" {
   value       = google_service_account.sa.email
 }
 
+output "iam_email" {
+  description = "IAM format service account email"
+  value       = "serviceAccount:${google_service_account.sa.email}"
+}
+
 output "id" {
   description = "Service account id and email"
   value = {

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -21,7 +21,7 @@ output "email" {
 
 output "iam_email" {
   description = "IAM format service account email"
-  value       = "serviceAccount:${google_service_account.sa.email}"
+  value       = google_service_account.sa.member
 }
 
 output "id" {
@@ -35,5 +35,5 @@ output "id" {
 output "env_vars" {
   description = "Exported environment variables"
   value = { "SERVICE_ACCOUNT_EMAIL" : google_service_account.sa.email,
-  "SERVICE_ACCOUNT_IAM_EMAIL" : "serviceAccount:${google_service_account.sa.email}" }
+  "SERVICE_ACCOUNT_IAM_EMAIL" : google_service_account.sa.member }
 }

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -26,3 +26,8 @@ output "id" {
     email = google_service_account.sa.email
   }
 }
+
+output "env_vars" {
+  description = "Exported environment variables"
+  value = { "SERVICE_ACCOUNT": google_service_account.sa.email}
+}

--- a/test/integration/simple_sa/simple_sa_test.go
+++ b/test/integration/simple_sa/simple_sa_test.go
@@ -37,6 +37,12 @@ func TestSimpleSA(t *testing.T) {
 			for _, b := range bindings {
 				assert.Contains(expectedRoles, b.Get("bindings.role").String())
 			}
+
+			iam_email := sa.GetStringOutput("iam_email")
+			env_vars := sa.GetStringOutput("env_vars")
+			assert.Contains(iam_email, "serviceAccount:")
+			assert.Contains(env_vars, "SERVICE_ACCOUNT_EMAIL")
+			assert.Contains(env_vars, "SERVICE_ACCOUNT_IAM_EMAIL")
 		})
 	sa.Test()
 }


### PR DESCRIPTION

This PR makes below changes,

1. Adds new output `iam_email`
2. Adds new output  `env_vars`