### PR TITLE
fix: Update the format of "id" output in the "simple-sa" module

### DIFF
--- a/modules/simple-sa/README.md
+++ b/modules/simple-sa/README.md
@@ -38,6 +38,6 @@ module "sa" {
 | email | Service account email |
 | env\_vars | Exported environment variables |
 | iam\_email | IAM format service account email |
-| id | Service account id and email |
+| id | Service account id in the format 'projects/{{project}}/serviceAccounts/{{email}}' |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -25,11 +25,8 @@ output "iam_email" {
 }
 
 output "id" {
-  description = "Service account id and email"
-  value = {
-    id    = google_service_account.sa.account_id,
-    email = google_service_account.sa.email
-  }
+  description = "Service account id in the format 'projects/{{project}}/serviceAccounts/{{email}}'"
+  value       = google_service_account.sa.account_id
 }
 
 output "env_vars" {


### PR DESCRIPTION
Currently the output `id` returns a map containing both service account id and e-mail, which is misleading.
There is already a separate output for the e-mail, called `email`.

So, in this PR I suggest to make the output `id` returning just a service account ID instead of the map.
I didn't mark this change as a breaking change, because there was no release cut yet since the original implementation of "simple-sa" module was merged.
