### PR TITLE
fix: Fix output "id" in "simple-sa" module

### DIFF
--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -26,7 +26,7 @@ output "iam_email" {
 
 output "id" {
   description = "Service account id in the format 'projects/{{project}}/serviceAccounts/{{email}}'"
-  value       = google_service_account.sa.account_id
+  value       = google_service_account.sa.id
 }
 
 output "env_vars" {


### PR DESCRIPTION
That is a follow up to my previous PR: #123.  I used a wrong attribute there, sorry about that!

The attribute `account_id` contains only the name of the service account (passed as `var.name`).
In order to get a fully-qualified service ID we should use the `id` attribute instead.