### PR TITLE
chore: Add new output account_details, output type and metadata.display.yaml

### DIFF
--- a/modules/simple-sa/README.md
+++ b/modules/simple-sa/README.md
@@ -35,6 +35,7 @@ module "sa" {
 
 | Name | Description |
 |------|-------------|
+| account\_details | Service account id and email |
 | email | Service account email |
 | env\_vars | Exported environment variables |
 | iam\_email | IAM format service account email |

--- a/modules/simple-sa/metadata.display.yaml
+++ b/modules/simple-sa/metadata.display.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-service-accounts-display
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Terraform Simple Service Account module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-service-accounts.git
+      sourceType: git
+      dir: /modules/simple-sa
+  ui:
+    input:
+      variables:
+        description:
+          name: description
+          title: Description
+        display_name:
+          name: display_name
+          title: Display Name
+        name:
+          name: name
+          title: Name
+        project_id:
+          name: project_id
+          title: Project Id
+        project_roles:
+          name: project_roles
+          title: Project Roles

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -63,14 +63,27 @@ spec:
         varType: list(string)
         required: true
     outputs:
+      - name: account_details
+        description: Service account id and email
+        type:
+          - object
+          - email: string
+            id: string
       - name: email
         description: Service account email
+        type: string
       - name: env_vars
         description: Exported environment variables
+        type:
+          - object
+          - SERVICE_ACCOUNT_EMAIL: string
+            SERVICE_ACCOUNT_IAM_EMAIL: string
       - name: iam_email
         description: IAM format service account email
+        type: string
       - name: id
-        description: Service account id and email
+        description: Service account id in the format 'projects/{{project}}/serviceAccounts/{{email}}'
+        type: string
   requirements:
     roles:
       - level: Project

--- a/modules/simple-sa/outputs.tf
+++ b/modules/simple-sa/outputs.tf
@@ -29,6 +29,14 @@ output "id" {
   value       = google_service_account.sa.id
 }
 
+output "account_details" {
+  description = "Service account id and email"
+  value = {
+    "id" : google_service_account.sa.account_id,
+    "email" : google_service_account.sa.email
+  }
+}
+
 output "env_vars" {
   description = "Exported environment variables"
   value = { "SERVICE_ACCOUNT_EMAIL" : google_service_account.sa.email,


### PR DESCRIPTION
This PR makes below changes,

1. Adds new output account_details. https://github.com/terraform-google-modules/terraform-google-service-accounts/pull/123 updated output `id`. This new account_details output takes place of earstwhile `id` output which is used by ADC.
2. Adds metadata.display.yaml for `modules/simple-sa`
3. Updates metadata.yaml and adds output type for `modules/simple-sa`