### PR TITLE
feat: per module requirements to service accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -79,7 +79,7 @@ docker_generate_docs:
 	  -e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs --per-module-requirements'
 
 # Alias for backwards compatibility
 .PHONY: generate_docs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ spec:
     version: 4.5.4
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     subBlueprints:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -122,18 +122,14 @@ spec:
       - level: Project
         roles:
           - roles/resourcemanager.projectIamAdmin
+          - roles/serviceusage.serviceUsageAdmin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountKeyAdmin
-          - roles/storage.admin
-          - roles/cloudfunctions.admin
-          - roles/serviceusage.serviceUsageAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
+      - secretmanager.googleapis.com
       - serviceusage.googleapis.com
-      - cloudfunctions.googleapis.com
-      - cloudbuild.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 3.53, < 7"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -123,7 +123,6 @@ spec:
         roles:
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
-          - roles/secretmanager.secretAdmin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
     services:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -123,6 +123,7 @@ spec:
         roles:
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
+          - roles/secretmanager.secretAdmin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
     services:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -121,10 +121,10 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountUser
     services:
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com

--- a/modules/key-distributor/metadata.yaml
+++ b/modules/key-distributor/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 4.5.4
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -85,10 +85,10 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountKeyAdmin
           - roles/iam.serviceAccountUser
           - roles/secretmanager.secretAdmin
           - roles/logging.logWriter
-          - roles/iam.serviceAccountKeyAdmin
     services:
       - iam.googleapis.com
       - secretmanager.googleapis.com

--- a/modules/key-distributor/metadata.yaml
+++ b/modules/key-distributor/metadata.yaml
@@ -85,19 +85,14 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/resourcemanager.projectIamAdmin
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
+          - roles/secretmanager.secretAdmin
+          - roles/logging.logWriter
           - roles/iam.serviceAccountKeyAdmin
-          - roles/storage.admin
-          - roles/cloudfunctions.admin
-          - roles/serviceusage.serviceUsageAdmin
     services:
-      - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
+      - secretmanager.googleapis.com
       - serviceusage.googleapis.com
-      - cloudfunctions.googleapis.com
-      - cloudbuild.googleapis.com
     providerVersions:
       - source: hashicorp/archive
         version: ">= 2.2"

--- a/modules/key-distributor/metadata.yaml
+++ b/modules/key-distributor/metadata.yaml
@@ -87,7 +87,6 @@ spec:
         roles:
           - roles/iam.serviceAccountKeyAdmin
           - roles/iam.serviceAccountUser
-          - roles/secretmanager.secretAdmin
           - roles/logging.logWriter
     services:
       - iam.googleapis.com

--- a/modules/key-distributor/versions.tf
+++ b/modules/key-distributor/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
   required_providers {
 
     google = {

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -134,19 +134,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountKeyAdmin
-          - roles/storage.admin
-          - roles/cloudfunctions.admin
-          - roles/serviceusage.serviceUsageAdmin
     services:
-      - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
       - serviceusage.googleapis.com
-      - cloudfunctions.googleapis.com
-      - cloudbuild.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 3.53, < 7"

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 4.5.4
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13.0"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -134,9 +134,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - iam.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -134,10 +134,12 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/resourcemanager.projectIamAdmin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
     services:
+      - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
       - serviceusage.googleapis.com
     providerVersions:

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -134,9 +134,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/logging.logWriter
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
-          - roles/logging.logWriter
     services:
       - iam.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/simple-sa/metadata.yaml
+++ b/modules/simple-sa/metadata.yaml
@@ -134,9 +134,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - iam.googleapis.com
       - serviceusage.googleapis.com

--- a/modules/simple-sa/versions.tf
+++ b/modules/simple-sa/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     google = {

--- a/test/fixtures/multiple_service_accounts/versions.tf
+++ b/test/fixtures/multiple_service_accounts/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3"
 }

--- a/test/fixtures/single_service_account/versions.tf
+++ b/test/fixtures/single_service_account/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3"
 }

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,15 +15,31 @@
  */
 
 locals {
-  int_required_roles = [
-    "roles/resourcemanager.projectIamAdmin",
-    "roles/iam.serviceAccountAdmin",
-    "roles/iam.serviceAccountUser",
-    "roles/iam.serviceAccountKeyAdmin",
+
+  per_module_roles = {
+    key-distributor = [
+      "roles/iam.serviceAccountKeyAdmin",
+      "roles/iam.serviceAccountUser",
+      "roles/secretmanager.secretAdmin",
+      "roles/logging.logWriter",
+    ]
+    simple-sa = [
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+    root = [
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountUser",
+    ]
+  }
+
+  int_required_roles = concat([
     "roles/storage.admin",
     "roles/cloudfunctions.admin",
-    "roles/serviceusage.serviceUsageAdmin",
-  ]
+  ], flatten(values(local.per_module_roles)))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -20,7 +20,6 @@ locals {
     key-distributor = [
       "roles/iam.serviceAccountKeyAdmin",
       "roles/iam.serviceAccountUser",
-      "roles/secretmanager.secretAdmin",
       "roles/logging.logWriter",
     ]
     simple-sa = [
@@ -31,7 +30,6 @@ locals {
     root = [
       "roles/resourcemanager.projectIamAdmin",
       "roles/serviceusage.serviceUsageAdmin",
-      "roles/secretmanager.secretAdmin",
       "roles/iam.serviceAccountAdmin",
       "roles/iam.serviceAccountUser",
     ]
@@ -39,7 +37,7 @@ locals {
 
   int_required_roles = concat([
     "roles/storage.admin",
-    "roles/secretmanager.secretAdmin",
+    "roles/secretmanager.admin",
     "roles/cloudfunctions.admin",
   ], flatten(values(local.per_module_roles)))
 }

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -23,6 +23,7 @@ locals {
       "roles/logging.logWriter",
     ]
     simple-sa = [
+      "roles/resourcemanager.projectIamAdmin",
       "roles/iam.serviceAccountAdmin",
       "roles/iam.serviceAccountUser",
       "roles/logging.logWriter",

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -31,6 +31,7 @@ locals {
     root = [
       "roles/resourcemanager.projectIamAdmin",
       "roles/serviceusage.serviceUsageAdmin",
+      "roles/secretmanager.secretAdmin",
       "roles/iam.serviceAccountAdmin",
       "roles/iam.serviceAccountUser",
     ]
@@ -38,6 +39,7 @@ locals {
 
   int_required_roles = concat([
     "roles/storage.admin",
+    "roles/secretmanager.secretAdmin",
     "roles/cloudfunctions.admin",
   ], flatten(values(local.per_module_roles)))
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,26 @@
  * limitations under the License.
  */
 
+locals {
+  per_module_services = {
+    key-distributor = [
+      "iam.googleapis.com",
+      "secretmanager.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    simple-sa = [
+      "iam.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+    root = [
+      "iam.googleapis.com",
+      "secretmanager.googleapis.com",
+      "serviceusage.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+    ]
+  }
+}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 18.0"
@@ -24,11 +44,8 @@ module "project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
-  activate_apis = [
-    "cloudresourcemanager.googleapis.com",
-    "iam.googleapis.com",
-    "serviceusage.googleapis.com",
+  activate_apis = concat([
     "cloudfunctions.googleapis.com",
     "cloudbuild.googleapis.com",
-  ]
+  ], flatten(values(local.per_module_services)))
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -45,6 +45,7 @@ module "project" {
   billing_account   = var.billing_account
 
   activate_apis = concat([
+    "secretmanager.googleapis.com",
     "cloudfunctions.googleapis.com",
     "cloudbuild.googleapis.com",
   ], flatten(values(local.per_module_services)))

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -24,6 +24,7 @@ locals {
     simple-sa = [
       "iam.googleapis.com",
       "serviceusage.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
     ]
     root = [
       "iam.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.3"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
   required_providers {
 
     google = {


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.